### PR TITLE
Ensure that `furi_record_create` is passed a non-NULL data pointer

### DIFF
--- a/furi/core/record.c
+++ b/furi/core/record.c
@@ -80,6 +80,7 @@ bool furi_record_exists(const char* name) {
 void furi_record_create(const char* name, void* data) {
     furi_check(furi_record);
     furi_check(name);
+    furi_check(data);
 
     furi_record_lock();
 


### PR DESCRIPTION
It's currently possible to use `furi_record_create` to create and initialize a `FuriRecordData` pointing to NULL.

This means its potentially possible for `furi_record_open` to return a NULL pointer which besides not being particularly useful means the Rust wrapper for `Record` can't assume that the returned record is always a non-NULL value.

If by chance this is the intended behaviour, then we can just have the Rust wrapper do a `furi_check` itself, but it seems like it would be better to eliminate this potential corner-case at the source.

# What's new

- `furi_record_create` now checks that `data` is a non-NULL pointer

# Verification 

- Calling `furi_record_create` with a NULL `data` pointer should trigger a `furi_check` system crash

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
